### PR TITLE
Alpine Linux apk packages

### DIFF
--- a/packaging/Dockerfile.alpine
+++ b/packaging/Dockerfile.alpine
@@ -1,0 +1,4 @@
+ARG DISTRO
+FROM alpine:$DISTRO
+RUN apk --no-cache add ruby ruby-bundler ruby-dev ruby-rdoc ruby-irb libffi-dev build-base tar git bash
+RUN gem install fpm

--- a/packaging/build-package.sh
+++ b/packaging/build-package.sh
@@ -4,13 +4,15 @@
 #
 # Inputs:
 # $PACKAGE_VERSION is the package version to use.
-# $PACKAGE_TYPE is rpm or deb.
+# $PACKAGE_TYPE is rpm, deb or apk.
 # Command line arguments are the dependencies.
 set -e
 
 # Set proper ownership before exiting, so the created packages aren't owned by
-# root.
-trap 'chown -R --reference /build-inside/build-package.sh /out/' EXIT
+# root. (--reference not supported on Alpine)
+if [ ! -f /etc/alpine-release ]; then
+    trap 'chown -R --reference /build-inside/build-package.sh /out/' EXIT
+fi
 
 # Package only includes /usr/bin/telepresence:
 mkdir /tmp/build

--- a/packaging/upload-linux-packages.py
+++ b/packaging/upload-linux-packages.py
@@ -33,6 +33,14 @@ class Uploader(object):
         )
         self._upload(file_path, "telepresence-rpm", "fedora/" + release)
 
+    def upload_alpine(self, release):
+        """Upload a .apk for a specific Alpine release, e.g. '3.5'."""
+        file_path = (
+            PACKAGES / ("alpine-" + release) /
+            "telepresence_{}_noarch.apk".format(self.version)
+        )
+        self._upload(file_path, "telepresence", "alpine/" + release)
+
     def _upload(self, file_path, repository, distro):
         """Upload a file to a repository.
 
@@ -54,7 +62,11 @@ def main(version):
     uploader = Uploader(version)
     for release in ["xenial", "yakkety", "zesty"]:
         uploader.upload_ubuntu(release)
+
     uploader.upload_fedora("25")
+
+    for release in ["3.5", "3.6"]:
+        uploader.upload_alpine(release)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Builds client .apk packages for Alpine Linux 3.5 and 3.6. This distro is very popular for containers given it's small footprint.

The publishing/uploading hasn't been tested but hopefully it works straight away 😳 

Note that for building on Alpine it first generates a local image with the FPM requirement.