### PR TITLE
Use local env to run docker

### DIFF
--- a/cli/telepresence
+++ b/cli/telepresence
@@ -1673,16 +1673,16 @@ def run_local_command(
         p = Popen(command, env=env)
     elif args.method == "container":
         # Don't want local environment:
-        env = env_overrides.copy()
-        env["TELEPRESENCE_ROOT"] = mount_dir
-        env["TELEPRESENCE_METHOD"] = "container"  # mostly just for tests :(
+        container_env = env_overrides.copy()
+        container_env["TELEPRESENCE_ROOT"] = mount_dir
+        container_env["TELEPRESENCE_METHOD"] = "container"  # mostly just for tests :(
         proxy_container_name, envfile_path = connect_docker(
-            runner, remote_info, args, subprocesses, env, ssh
+            runner, remote_info, args, subprocesses, container_env, ssh
         )
         container_name = random_name()
         docker_command = docker_runify([
             "--volume={}:{}".format(
-                env["TELEPRESENCE_ROOT"], env["TELEPRESENCE_ROOT"]
+                container_env["TELEPRESENCE_ROOT"], container_env["TELEPRESENCE_ROOT"]
             ),
             "--name=" + container_name,
             "--network=container:" + proxy_container_name,


### PR DESCRIPTION
Fixes #221 

I hope this is the correct fix, at least it works for me.

Problem seems to be that `env` got overwritten with the environment settings for the container, but then also used in `p = Popen(docker_command, env=env)`.

That might work fine when the paths are the same, but on OSX docker's path is `/usr/local/bin/docker` by default, not `/usr/bin/docker`, like on UNIX. I expect that is why docker could not be found.