### PR TITLE
Add support for deployments using `automountServiceAccountToken: false`

### DIFF
--- a/cli/telepresence
+++ b/cli/telepresence
@@ -1295,7 +1295,6 @@ def swap_deployment(runner: Runner,
         TELEPRESENCE_REMOTE_IMAGE,
         args.method == "vpn-tcp" and args.in_local_vm,
         args.needs_root,
-        args.namespace,
     )
     apply_json(new_deployment_json)
     return deployment_name, run_id, orig_container_json
@@ -1308,7 +1307,6 @@ def new_swapped_deployment(
     telepresence_image: str,
     add_custom_nameserver: bool,
     as_root: bool,
-    namespace: str,
 ) -> Tuple[Dict, Dict]:
     """
     Create a new Deployment that uses telepresence-k8s image.
@@ -1370,10 +1368,12 @@ def new_swapped_deployment(
             in the k8s-proxy.
             """
             container.setdefault("env", []).append({
-                    "name":
-                    "TELEPRESENCE_CONTAINER_NAMESPACE",
-                    "value":
-                    namespace
+                    "name": "TELEPRESENCE_CONTAINER_NAMESPACE",
+                    "valueFrom": {
+                        "fieldRef": {
+                            "fieldPath": "metadata.namespace"
+                        }
+                    }
                 })
             return new_deployment_json, old_container
 
@@ -1448,7 +1448,6 @@ def swap_deployment_openshift(runner: Runner, args: argparse.Namespace
         TELEPRESENCE_REMOTE_IMAGE,
         args.method == "vpn-tcp" and args.in_local_vm,
         False,
-        args.namespace
     )
     apply_json(new_rc_json)
     return deployment_name, run_id, orig_container_json

--- a/cli/telepresence
+++ b/cli/telepresence
@@ -1295,6 +1295,7 @@ def swap_deployment(runner: Runner,
         TELEPRESENCE_REMOTE_IMAGE,
         args.method == "vpn-tcp" and args.in_local_vm,
         args.needs_root,
+        args.namespace,
     )
     apply_json(new_deployment_json)
     return deployment_name, run_id, orig_container_json
@@ -1307,6 +1308,7 @@ def new_swapped_deployment(
     telepresence_image: str,
     add_custom_nameserver: bool,
     as_root: bool,
+    namespace: str,
 ) -> Tuple[Dict, Dict]:
     """
     Create a new Deployment that uses telepresence-k8s image.
@@ -1362,6 +1364,17 @@ def new_swapped_deployment(
                 container["securityContext"] = {
                     "runAsUser": 0,
                 }
+            """
+            Add namespace environment variable to support deployments using
+            automountServiceAccountToken: false. To be used by forwarder.py
+            in the k8s-proxy.
+            """
+            container.setdefault("env", []).append({
+                    "name":
+                    "TELEPRESENCE_CONTAINER_NAMESPACE",
+                    "value":
+                    namespace
+                })
             return new_deployment_json, old_container
 
     raise RuntimeError(
@@ -1429,8 +1442,13 @@ def swap_deployment_openshift(runner: Runner, args: argparse.Namespace
                                                              ][0]["name"]
 
     new_rc_json, orig_container_json = new_swapped_deployment(
-        rc_json, container_name, run_id, TELEPRESENCE_REMOTE_IMAGE,
-        args.method == "vpn-tcp" and args.in_local_vm, False,
+        rc_json,
+        container_name,
+        run_id,
+        TELEPRESENCE_REMOTE_IMAGE,
+        args.method == "vpn-tcp" and args.in_local_vm,
+        False,
+        args.namespace
     )
     apply_json(new_rc_json)
     return deployment_name, run_id, orig_container_json

--- a/k8s-proxy/forwarder.py
+++ b/k8s-proxy/forwarder.py
@@ -228,8 +228,12 @@ def listen():
     reactor.listenUDP(9053, protocol)
 
 
-with open("/var/run/secrets/kubernetes.io/serviceaccount/namespace") as f:
-    NAMESPACE = f.read()
+predefined_namespace = os.getenv('TELEPRESENCE_CONTAINER_NAMESPACE', None)
+if predefined_namespace:
+    NAMESPACE = predefined_namespace
+else:
+    with open("/var/run/secrets/kubernetes.io/serviceaccount/namespace") as f:
+        NAMESPACE = f.read()
 NOLOOP = os.environ.get("TELEPRESENCE_NAMESERVER") is not None
 reactor.suggestThreadPoolSize(50)
 print("Listening...")

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -147,6 +147,11 @@ spec:
           name: secret-volume
         - mountPath: /etc/nginx/conf.d
           name: configmap-volume
+        env:
+        - name: TELEPRESENCE_CONTAINER_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
 """
 
 


### PR DESCRIPTION
We are using non default deployments. Meaning that we prevent the default service account to be mounted. This makes `/var/run/secrets/kubernetes.io/serviceaccount/namespace` unavailable to be used by forwarder.py.