### PR TITLE
Docs bugs

### DIFF
--- a/docs/book.json
+++ b/docs/book.json
@@ -2,6 +2,7 @@
   "title": "Telepresence: Fast, realistic local development for Kubernetes and OpenShift Origin microservices",
   "root": ".",
   "variables": {
+    "version": "2.2",
     "baseUrl": "https://www.telepresence.io"
   },
   "structure": {

--- a/docs/book.json
+++ b/docs/book.json
@@ -2,7 +2,7 @@
   "title": "Telepresence: Fast, realistic local development for Kubernetes and OpenShift Origin microservices",
   "root": ".",
   "variables": {
-    "version": "2.2",
+    "version": "0.67",
     "baseUrl": "https://www.telepresence.io"
   },
   "structure": {

--- a/docs/discussion/why-telepresence.md
+++ b/docs/discussion/why-telepresence.md
@@ -1,13 +1,5 @@
 # Why Telepresence?
 
-<link rel="stylesheet" href="{{ "/css/mermaid.css" }}">
-<script src="{{ "/js/mermaid.min.js" }}"></script>
-<script>mermaid.initialize({
-   startOnLoad: true,
-   cloneCssStyles: false,
- });
-</script>
-
 Let's assume you have a web service which listens on port 8080, and has a Dockerfile which gets built to an image called `examplecom/servicename`.
 Your service depends on other Kubernetes `Service` instances (`thing1` and `thing2`), and on a cloud database.
 

--- a/docs/js/install-instructions.js
+++ b/docs/js/install-instructions.js
@@ -14,12 +14,9 @@ $(document).ready(function() {
         e.clearSelection();
     });
 
-    var path = null;
+    window.mermaid.init(undefined, document.querySelectorAll('.mermaid'));
 
-    setInterval(function() {
-        if (path !== window.location.pathname) {
-            path = window.location.pathname;
-            window.mermaid.init(undefined, document.querySelectorAll('.lang-mermaid'))
-        }
-    }, 1000);
+    gitbook.events.bind("page.change", function() {
+       window.mermaid.init(undefined, document.querySelectorAll('.mermaid'));
+    });
 });

--- a/docs/reference/connecting.md
+++ b/docs/reference/connecting.md
@@ -51,13 +51,12 @@ You can also choose to run the Telepresence manually by starting a `Deployment` 
 
 The `Deployment` should only have 1 replica, and use the Telepresence different image:
 
-```yaml
-apiVersion: extensions/v1beta1
+<pre><code class="lang-yaml">apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: myservice
 spec:
-  replicas: 1  # <-- only one replica
+  replicas: 1  # only one replica
   template:
     metadata:
       labels:
@@ -65,8 +64,8 @@ spec:
     spec:
       containers:
       - name: myservice
-        image: datawire/telepresence-k8s:{{ book['version']) }}  # <-- new image
-```
+        image: datawire/telepresence-k8s:{{ book['version'] }}  # new image
+</code></pre>
 
 You should apply this file to your cluster:
 

--- a/docs/reference/connecting.md
+++ b/docs/reference/connecting.md
@@ -65,7 +65,7 @@ spec:
     spec:
       containers:
       - name: myservice
-        image: datawire/telepresence-k8s:{{ site.data.version.version }}  # <-- new image
+        image: datawire/telepresence-k8s:{{ book['version']) }}  # <-- new image
 ```
 
 You should apply this file to your cluster:

--- a/docs/reference/limitations.md
+++ b/docs/reference/limitations.md
@@ -19,8 +19,7 @@ This can be a problem in cases where you are running multiple containers in a po
 The solution is to access the pod via its IP, rather than at `127.0.0.1`.
 You can have the pod IP configured as an environment variable `$MY_POD_IP` in the Deployment using the Kubernetes [Downward API](https://kubernetes.io/docs/tasks/configure-pod-container/environment-variable-expose-pod-information/):
 
-```yaml
-apiVersion: extensions/v1beta1
+<pre><code class="lang-yaml">apiVersion: extensions/v1beta1
 kind: Deployment
 spec:
   template:
@@ -33,4 +32,4 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
-```
+</code></pre>

--- a/docs/reference/limitations.md
+++ b/docs/reference/limitations.md
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: servicename
-        image: datawire/telepresence-k8s:{{ site.data.version.version }}
+        image: datawire/telepresence-k8s:{{ book['version'] }}
         env:
         - name: MY_POD_IP
           valueFrom:


### PR DESCRIPTION
This pr addresses the issues brought up in issue [#316](https://github.com/datawire/telepresence/issues/316).

The markdown rendering engine that Gitbook uses [escapes everything within a code block](https://github.com/GitbookIO/gitbook/issues/707), therefore when we want to print a variable inside a code block like the version number, the only way that I have found to do that is to wrap the block like this:
```
<pre><code class="lang-yaml>
apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: {{ my_variable }}
 spec:
</code></pre>
```
If there is a better way to do this please let me know, as it is odd to have to use a block of html while writing markdown.

The version number is now stored as a variable in the book.json file