### PR TITLE
Add support for deployments containing Services of type ExternalName

### DIFF
--- a/cli/telepresence
+++ b/cli/telepresence
@@ -1816,7 +1816,7 @@ def get_proxy_cidrs(
         )["items"]
         return [
             svc["spec"]["clusterIP"] for svc in services
-            if svc["spec"]["clusterIP"] != "None"
+            if "clusterIP" in svc["spec"] and svc["spec"]["clusterIP"] != "None"
         ]
 
     service_ips = get_service_ips()


### PR DESCRIPTION
We have some services in our cluster of type ExternalName. These are essentially service definitions pointing to external services. As such, the spec does not contain a `clusterIP` field, but an `externalName` field instead. Telepresence currently crashes on these service definitions because it expects a service spec to always have a `clusterIP` field.