### PR TITLE
Parse env for docker-command args

### DIFF
--- a/cli/telepresence
+++ b/cli/telepresence
@@ -1965,6 +1965,7 @@ def run_docker_command(
     )
 
     # Update environment:
+    os.environ["TELEPRESENCE_ROOT"] = mount_dir
     remote_env["TELEPRESENCE_ROOT"] = mount_dir
     remote_env["TELEPRESENCE_METHOD"] = "container"  # mostly just for tests :(
 
@@ -2036,7 +2037,8 @@ def run_docker_command(
     # Older versions of Docker don't have --init:
     if "--init" in runner.get_output(["docker", "run", "--help"]):
         docker_command += ["--init"]
-    docker_command += args.docker_run
+    for arg in args.docker_run:
+        docker_command += [os.path.expandvars(arg)]
     p = Popen(docker_command)
 
     def terminate_if_alive():


### PR DESCRIPTION
Adds the ability for a user to pass an argument such as `--docker-run -v \$TELEPRESENCE_ROOT/var/run/secrets/:/var/run/secrets <image_name>`.

This means that containers running in docker can have their volumes remapped to the correct locations by the user when they run telepresence.

Currently docs suggest using `proot` for this sort of thing, but you can't mount things from within a container so this won't work.