### PR TITLE
PS1 environment functions

### DIFF
--- a/cli/telepresence
+++ b/cli/telepresence
@@ -2118,7 +2118,12 @@ def run_local_command(
         # We skip .bashrc since it might e.g. have kubectl running to get bash
         # autocomplete, and Go programs don't like DYLD on macOS at least (see
         # https://github.com/datawire/telepresence/issues/125).
-        command = ["bash", "--norc"]
+        # If we have a .bashrc.telepresence we'll use that instead thou
+        rc_file = os.path.join(os.path.expanduser('~'), '.bashrc.telepresence')
+        if os.path.isfile(rc_file):
+            command = ["bash", "--rcfile", rc_file]
+        else:
+            command = ["bash", "--norc"]
     else:
         command = args.run
     if args.method == "inject-tcp":


### PR DESCRIPTION
I've __git_ps1 in my PS1, and `. /etc/bash_completion` is run from `~/.bashrc`, and because telepresence is running bash with --no-rc this file is not executed and thus I'm getting "bash: __git_ps1: command not found"

Would it be possible to have a `~/.telepresencerc` instead that could include relevant stuff?