### PR TITLE
Some generalization of build-linux.sh

### DIFF
--- a/build-linux.sh
+++ b/build-linux.sh
@@ -49,12 +49,14 @@ make setup
 
 # Build and push images
 make build-local build-k8s-proxy
-docker tag "datawire/telepresence-local:${TELEPRESENCE_VERSION}" \
-           "${TELEPRESENCE_REGISTRY}/telepresence-local:${TELEPRESENCE_VERSION}"
-docker push "${TELEPRESENCE_REGISTRY}/telepresence-local:${TELEPRESENCE_VERSION}"
 docker tag "datawire/telepresence-k8s:${TELEPRESENCE_VERSION}" \
            "${TELEPRESENCE_REGISTRY}/telepresence-k8s:${TELEPRESENCE_VERSION}"
 docker push "${TELEPRESENCE_REGISTRY}/telepresence-k8s:${TELEPRESENCE_VERSION}"
+
+docker tag "datawire/telepresence-local:${TELEPRESENCE_VERSION}" \
+           "${TELEPRESENCE_REGISTRY}/telepresence-local:${TELEPRESENCE_VERSION}"
+docker push "${TELEPRESENCE_REGISTRY}/telepresence-local:${TELEPRESENCE_VERSION}"
+
 
 # Get a Kubernetes cluster
 #kubernaut claim

--- a/build-linux.sh
+++ b/build-linux.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# Plan:
+# (1) Make it work for me
+# (2) Rewrite it in Python
+# (3) Refactor out duplication with build-macos.sh
+# (4) Make it usable in .travis.yaml
+
 # Build script for Linux automated builds
 
 set -eEx

--- a/build-linux.sh
+++ b/build-linux.sh
@@ -4,6 +4,11 @@
 
 set -eEx
 
+# Attempt to get credentials cached early on while the user is still looking
+# at the terminal.  They'll be required later on during the test suite run and
+# the prompt is likely to be buried in test output at that point.
+sudo echo -n
+
 export SCOUT_DISABLE=1
 export PROJECT_NAME=datawireio
 export CLUSTER_NAME=telepresence-testing
@@ -46,8 +51,17 @@ docker push "${TELEPRESENCE_REGISTRY}/telepresence-k8s:${TELEPRESENCE_VERSION}"
 # Run tests
 #export TELEPRESENCE_TESTS="-xs"
 export TELEPRESENCE_TESTS="-xs -k fromcluster"
-#env TELEPRESENCE_METHOD=container ./ci/test.sh
+
+# Refresh the credentials
+# sudo echo -n
+# env TELEPRESENCE_METHOD=container ./ci/test.sh
+
+# Refresh the credentials
+sudo echo -n
 env TELEPRESENCE_METHOD=inject-tcp ./ci/test.sh
+
+# Refresh the credentials
+sudo echo -n
 env TELEPRESENCE_METHOD=vpn-tcp ./ci/test.sh
 
 # Cleanup

--- a/build-linux.sh
+++ b/build-linux.sh
@@ -17,6 +17,12 @@ if [ -z "${TELEPRESENCE_REGISTRY}" ]; then
 fi
 shift
 
+# Provide additional arguments to py.test
+if [ $# -gt 0 ]; then
+    export TELEPRESENCE_TESTS="$1"
+    shift
+fi
+
 # Attempt to get credentials cached early on while the user is still looking
 # at the terminal.  They'll be required later on during the test suite run and
 # the prompt is likely to be buried in test output at that point.
@@ -61,9 +67,6 @@ docker push "${TELEPRESENCE_REGISTRY}/telepresence-local:${TELEPRESENCE_VERSION}
 # Get a Kubernetes cluster
 #kubernaut claim
 #export KUBECONFIG=${HOME}/.kube/kubernaut
-
-# Provide additional arguments to py.test
-export TELEPRESENCE_TESTS="-xs"
 
 # Refresh the credentials
 # sudo echo -n

--- a/build-linux.sh
+++ b/build-linux.sh
@@ -34,7 +34,6 @@ export CLUSTER_NAME=telepresence-testing
 export CLOUDSDK_COMPUTE_ZONE=us-central1-a
 export TELEPRESENCE_VER_SUFFIX=$(date +-LNX-%s)
 export TELEPRESENCE_VERSION=$(make version)
-export PATH=$PATH:$PWD/virtualenv/bin:~/datawire/kubernaut/virtualenv/bin
 
 ci/setup-gcloud.sh
 
@@ -52,6 +51,10 @@ python3 --version
 # install
 rm -rf virtualenv
 make setup
+
+# `setup` created a new virtualenv for us.  Activate it so we find the
+# telepresence installed there.
+. virtualenv/bin/activate
 
 # Build and push images
 make build-local build-k8s-proxy

--- a/build-linux.sh
+++ b/build-linux.sh
@@ -10,6 +10,13 @@
 
 set -eEx
 
+export TELEPRESENCE_REGISTRY="$1"
+if [ -z "${TELEPRESENCE_REGISTRY}" ]; then
+    echo "Usage: build-linux-sh <docker telepresence registry>"
+    exit 11
+fi
+shift
+
 # Attempt to get credentials cached early on while the user is still looking
 # at the terminal.  They'll be required later on during the test suite run and
 # the prompt is likely to be buried in test output at that point.
@@ -21,7 +28,6 @@ export CLUSTER_NAME=telepresence-testing
 export CLOUDSDK_COMPUTE_ZONE=us-central1-a
 export TELEPRESENCE_VER_SUFFIX=$(date +-LNX-%s)
 export TELEPRESENCE_VERSION=$(make version)
-export TELEPRESENCE_REGISTRY=ark3
 export PATH=$PATH:$PWD/virtualenv/bin:~/datawire/kubernaut/virtualenv/bin
 
 ci/setup-gcloud.sh

--- a/build-linux.sh
+++ b/build-linux.sh
@@ -62,9 +62,8 @@ docker push "${TELEPRESENCE_REGISTRY}/telepresence-local:${TELEPRESENCE_VERSION}
 #kubernaut claim
 #export KUBECONFIG=${HOME}/.kube/kubernaut
 
-# Run tests
-#export TELEPRESENCE_TESTS="-xs"
-export TELEPRESENCE_TESTS="-xs -k fromcluster"
+# Provide additional arguments to py.test
+export TELEPRESENCE_TESTS="-xs"
 
 # Refresh the credentials
 # sudo echo -n

--- a/ci/push-images.sh
+++ b/ci/push-images.sh
@@ -6,9 +6,11 @@ TELEPRESENCE_VERSION=$(make version)
 
 make build-local
 make build-k8s-proxy
+
 docker tag "datawire/telepresence-k8s:${TELEPRESENCE_VERSION}" \
            "gcr.io/${PROJECT_NAME}/telepresence-k8s:${TELEPRESENCE_VERSION}"
 $HOME/google-cloud-sdk/bin/gcloud docker -- push "gcr.io/${PROJECT_NAME}/telepresence-k8s:${TELEPRESENCE_VERSION}"
+
 docker tag "datawire/telepresence-local:${TELEPRESENCE_VERSION}" \
        "gcr.io/${PROJECT_NAME}/telepresence-local:${TELEPRESENCE_VERSION}"
 $HOME/google-cloud-sdk/bin/gcloud docker -- push "gcr.io/${PROJECT_NAME}/telepresence-local:${TELEPRESENCE_VERSION}"

--- a/ci/setup-gcloud.sh
+++ b/ci/setup-gcloud.sh
@@ -7,10 +7,17 @@ if [ ! -d "$HOME/google-cloud-sdk/bin" ]; then
 fi
 export PATH=~/google-cloud-sdk/bin:$PATH
 
+SERVICE_KEY=gcloud-service-key.json
+
+if [ ! -e "${SERVICE_KEY}" ]; then
+    echo "Provide gcloud service account key in ``${SERVICE_KEY}``"
+    exit 1
+fi
+
 gcloud --quiet version
 gcloud --quiet components update
 gcloud --quiet components update kubectl
-gcloud auth activate-service-account --key-file gcloud-service-key.json
+gcloud auth activate-service-account --key-file "${SERVICE_KEY}"
 
 gcloud --quiet config set project $PROJECT_NAME
 gcloud --quiet config set container/cluster $CLUSTER_NAME

--- a/ci/setup-gcloud.sh
+++ b/ci/setup-gcloud.sh
@@ -11,6 +11,8 @@ SERVICE_KEY=gcloud-service-key.json
 
 if [ ! -e "${SERVICE_KEY}" ]; then
     echo "Provide gcloud service account key in ``${SERVICE_KEY}``"
+    echo "Obtain one from GCP Console:"
+    echo "    APIs & Services > Credentials > Create credentials > Service account key"
     exit 1
 fi
 


### PR DESCRIPTION
This is a *step* towards #374.  It lays out a plan:

```
# Plan:                                        
# (1) Make it work for me                      
# (2) Rewrite it in Python                     
# (3) Refactor out duplication with build-macos.sh                                             
# (4) Make it usable in .travis.yaml        
```

and accomplishes the first step.
