### PR TITLE
Reduce frequency of test_swapdeployment failures

### DIFF
--- a/telepresence/deployment.py
+++ b/telepresence/deployment.py
@@ -94,7 +94,7 @@ def swap_deployment(runner: Runner,
     def apply_json(json_config):
         runner.check_kubectl(
             args.context,
-            args.namespace, ["replace", "-f", "-"],
+            args.namespace, ["replace", "--force", "-f", "-"],
             input=json.dumps(json_config).encode("utf-8")
         )
 

--- a/telepresence/deployment.py
+++ b/telepresence/deployment.py
@@ -92,10 +92,17 @@ def swap_deployment(runner: Runner,
     )
 
     def apply_json(json_config):
+        # If we don't delete the deployment first (eg, if we perform a
+        # replace) then related ReplicaSets and Pods tend to hang around.
+        # This seems like a misbehavior of of Kuberentes.
+        runner.check_kubectl(
+            args.context, args.namespace,
+            ["delete", "deployment", deployment_name],
+        )
         runner.check_kubectl(
             args.context,
-            args.namespace, ["replace", "--force", "-f", "-"],
-            input=json.dumps(json_config).encode("utf-8")
+            args.namespace, ["apply", "-f", "-"],
+            input=json.dumps(json_config).encode("utf-8"),
         )
 
     atexit.register(apply_json, deployment_json)

--- a/telepresence/deployment.py
+++ b/telepresence/deployment.py
@@ -96,12 +96,14 @@ def swap_deployment(runner: Runner,
         # replace) then related ReplicaSets and Pods tend to hang around.
         # This seems like a misbehavior of of Kuberentes.
         runner.check_kubectl(
-            args.context, args.namespace,
+            args.context,
+            args.namespace,
             ["delete", "deployment", deployment_name],
         )
         runner.check_kubectl(
             args.context,
-            args.namespace, ["apply", "-f", "-"],
+            args.namespace,
+            ["apply", "-f", "-"],
             input=json.dumps(json_config).encode("utf-8"),
         )
 

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -674,22 +674,24 @@ class NativeEndToEndTests(TestCase):
                     ]), "utf-8"
                 )
             )["items"]
-            images = list(
-                pod["spec"]["containers"][0]["image"]
+            image_and_phase = list(
+                (pod["spec"]["containers"][0]["image"],
+                 pod["status"]["phase"])
                 for pod
                 in pods
+                if pod
             )
             if all(
                     image.startswith("openshift/hello-openshift")
-                    for image
-                    in images
+                    for (image, phase)
+                    in image_and_phase
             ):
                 print("Found openshift!")
                 return
             time.sleep(1)
 
             if time.time() - start > 60:
-                assert False, "Didn't switch back to openshift: {}".format(images)
+                assert False, "Didn't switch back to openshift: {}".format(image_and_phase)
 
     def test_swapdeployment_explicit_container(self):
         """

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -691,7 +691,14 @@ class NativeEndToEndTests(TestCase):
             time.sleep(1)
 
             if time.time() - start > 60:
-                assert False, "Didn't switch back to openshift: {}".format(image_and_phase)
+                assert False, \
+                    "Didn't switch back to openshift: \n\t{}\n{}".format(
+                        image_and_phase,
+                        check_output([
+                            KUBECTL, "get", "-o", "json", "all",
+                            "--selector", selector,
+                        ]),
+                    )
 
     def test_swapdeployment_explicit_container(self):
         """

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -679,7 +679,6 @@ class NativeEndToEndTests(TestCase):
                  pod["status"]["phase"])
                 for pod
                 in pods
-                if pod
             )
             if all(
                     image.startswith("openshift/hello-openshift")

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -3,13 +3,13 @@ End-to-end tests for running directly in the operating system.
 """
 
 import json
+from pprint import pformat
 from unittest import TestCase, skipIf, skipUnless
 from urllib.request import urlopen
 from subprocess import (
     check_output,
     Popen,
     PIPE,
-    CalledProcessError,
     check_call,
     run,
     STDOUT,
@@ -694,10 +694,10 @@ class NativeEndToEndTests(TestCase):
                 assert False, \
                     "Didn't switch back to openshift: \n\t{}\n{}".format(
                         image_and_phase,
-                        check_output([
+                        pformat(json.loads(check_output([
                             KUBECTL, "get", "-o", "json", "all",
                             "--selector", selector,
-                        ]),
+                        ]))),
                     )
 
     def test_swapdeployment_explicit_container(self):


### PR DESCRIPTION
Fixes #427 

Basically a revert of #420 plus a little better failure reporting for some tests.  Doesn't entirely make sense to me unless we buy "Kubernetes bug" as an explanation.  But CI says this is much more reliable, so ...