### PR TITLE
Disable travis linux testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ workflows:
   version: 2
   ci:
     jobs:
+      - lint
       - build-image
 
       - build-macos:
@@ -16,6 +17,26 @@ workflows:
             - "build-image"
 
 jobs:
+  lint:
+    docker:
+      # https://circleci.com/docs/2.0/circleci-images/
+      # https://hub.docker.com/r/circleci/python/
+      - image: "circleci/python:3"
+
+    steps:
+      - "checkout"
+
+      - run:
+          name: "setup Python environment"
+          command: |
+            sudo pip install --upgrade virtualenv
+            ./build --registry gcr.io/datawireio --manage-virtualenv
+
+      - run:
+          name: "run lint checks"
+          command: |
+            ./build --registry gcr.io/datawireio --lint
+
   build-image:
     docker:
       # https://circleci.com/docs/2.0/circleci-images/
@@ -185,11 +206,6 @@ jobs:
           paths:
             # OSX specific
             - "~/Library/Caches/pip/"
-
-      - run:
-          name: "run lint checks"
-          command: |
-            ./build --registry gcr.io/datawireio --lint
 
       - run:
           name: "run tests"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python:
   - "3.5"
 sudo: required
 
-# Run on Linux and OS X:
+# Run on Linux, only for releases.
 matrix:
   include:
     - os: linux
@@ -16,14 +16,8 @@ matrix:
 # Environment variables:
 env:
   global:
-    - SCOUT_DISABLE=1
-    - PROJECT_NAME=datawireio
-    - CLUSTER_NAME=telepresence-testing
-    - CLOUDSDK_COMPUTE_ZONE=us-central1-a
     # DOCKER_PASSWORD:
     - secure: "crKoRn+A2LQ/DTcndX204BsDCPXzl6twsrgoQ8CNmYD154n9bYWzg21uWPiaYFrZYYR3dxb8l40VOMTaFUp1iDM3QwA5U3rEdYBIDV0XK4ORvvr5xkmRj8qd7Fmub+lMPWb2euRVK8odSHMiNo111pfB5ddai2VadbwQhNGznuTcY5fNrrTGjCSusP+w4TV+Tz8f6dzsnx9ZduU2XYMh1mZkynHbJJ28o6l7O1jYxUtOGb9cFEvICNW9r2owbasaRL51SLOFJxNmgjpawm5FGyCCFnpfHT53aaj69FdquH1kAQCpHM4GRluu05Vx9Q+T60sZb2v1mgyzSkl2qAdQlniwvrcroYSSWcMPgNQDwjjpDlWRBdlPXqZbVf0TxTGsc+ZDrLrn7j5ZmrJMoItiqLLVmtsCZ53abFZZBcyoBjyY3dcg2lTU0NIAul93AjfonVK/BC84vSNhU6ePpZbEk1UtXQUNmUMciE9lF8rU8UeKyotZY8+gTVTnmHhv4dVwpePCMgfdnkZj/tfDKb+qrwU0bRi0KbUEsqI/At/kydcZD7L63lhHBW/Ptm82gXI788pgp2BzTuha41NWSu72bSmGFpdcwZNAxLrAJ8Ge4ns4nhihUIy7N9uY/UZX96UmITbjD8hQ3GKEvbpf9PHa0+RBD9irZUJOFatGxhDb6zk="
-
-
 
 # Only build master branch and tags of form 0.1 or 1.0.2 (all PRs will be built):
 branches:
@@ -31,23 +25,13 @@ branches:
     - master
     - /^\d+\.\d+(\.\d+)?$/
 
-# Install various dependencies:
-before_install:
-  # Decrypt the service key.  This only makes sense on travis.  All other
-  # environments should get a gcloud key some other way.
-  - "ci/decrypt-gcloud-key travisci $encrypted_6168b41c1bb0_key $encrypted_6168b41c1bb0_iv"
+# Release takes care of its own installation.
+install: |
+  :;
 
-  # Do the rest of the setup - which is a bit less particular to travis.
-  - "./environment-setup.sh ${PROJECT_NAME} ${CLUSTER_NAME} ${CLOUDSDK_COMPUTE_ZONE} ${TRAVIS_OS_NAME}"
-
-  # Also get google cloud sdk binaries (including kubectl) into PATH:
-  - "export PATH=${HOME}/google-cloud-sdk/bin:${PATH}"
-
-script:
-  - "./build --travis"
-
-after_script:
-  - "./ci/clean-cluster.py"
+# Nothing to do here.  Release will happen later, maybe.
+script: |
+  :;
 
 # If a commit is tagged, release the software:
 deploy:

--- a/build
+++ b/build
@@ -37,31 +37,7 @@ def main():
     except KeyError:
         pass
 
-    if args.travis:
-        manage_virtualenv = True
-        lint = True
-        registry = "gcr.io/" + environ["PROJECT_NAME"]
-        if platform == "linux":
-            # We'll do this on Linux and keep our fingers crossed that this is
-            # done by the time the OS X builder wants to pull any images.  On
-            # travis, this is a pretty safe bet as OS X has much longer build
-            # queues and takes longer to set up.
-            build_and_push = True
-        else:
-            build_and_push = False
-        version_suffix = ""
-        methods = ["inject-tcp", "vpn-tcp"]
-        if platform == "linux":
-            methods.insert(0, "container")
-        test_args = []
-        test_env = {
-            # Magic incantation to make kubectl work, because apparently
-            # gcloud can't do that correctly (see
-            # https://github.com/kubernetes/kubernetes/issues/30617)
-            "GOOGLE_APPLICATION_CREDENTIALS":
-            abspath("gcloud-service-key.json"),
-        }
-    elif args.circle:
+    if args.circle:
         manage_virtualenv = False
         registry = "gcr.io/" + environ["PROJECT_NAME"]
         version_suffix = ""
@@ -103,7 +79,7 @@ def main():
 
     if registry is None:
         raise SystemExit(
-            "You must specify a registry with --registry (or --travis)"
+            "You must specify a registry with --registry (or --circle)"
         )
 
     # Attempt to get credentials cached early on while the user is still
@@ -209,11 +185,6 @@ def _push(registry, version):
 
 def _parser():
     parser = ArgumentParser(description="Test Telepresence")
-    parser.add_argument(
-        '--travis',
-        action='store_true',
-        help='do all the things CI should do',
-    )
     parser.add_argument(
         '--circle',
         action='store_true',

--- a/build
+++ b/build
@@ -95,6 +95,12 @@ def main():
             )
             build_and_push = True
 
+    if methods:
+        if which("kubectl") is None:
+            raise SystemExit(
+                "Required executable 'kubectl' not found on $PATH.",
+            )
+
     if registry is None:
         raise SystemExit(
             "You must specify a registry with --registry (or --travis)"

--- a/build
+++ b/build
@@ -29,7 +29,7 @@ def main():
     parser = _parser()
     args = parser.parse_args()
 
-    for exe in {"gcloud", "kubectl"}:
+    for exe in {"kubectl"}:
         if which(exe) is None:
             raise SystemExit(
                 "Required executable {} not found on $PATH".format(exe)
@@ -302,10 +302,6 @@ def _lint():
         "mypy", "--ignore-missing-imports", "k8s-proxy/forwarder.py",
         "k8s-proxy/socks.py"
     )
-
-
-def _gcloud(*argv):
-    _run("gcloud", *argv)
 
 
 def _pip(*argv):

--- a/build
+++ b/build
@@ -29,12 +29,6 @@ def main():
     parser = _parser()
     args = parser.parse_args()
 
-    for exe in {"kubectl"}:
-        if which(exe) is None:
-            raise SystemExit(
-                "Required executable {} not found on $PATH".format(exe)
-            )
-
     try:
         # Presence of this variable in pip processes we launch causes pip to
         # write the wrong #! line.  Only expected to be set on OS X.

--- a/docs/reference/developing.md
+++ b/docs/reference/developing.md
@@ -97,7 +97,7 @@ In order to run *all* possible code paths in Telepresence, you need to do the fo
 | Test environment   | How to run                                           |
 |--------------------|------------------------------------------------------|
 | Minikube           | `make minikube-test`                                 |
-| Remote K8s cluster | Runs on Travis                                       |
+| Remote K8s cluster | Runs on Circle                                       |
 | Minishift          | `make openshift-tests` with minishift kube context   |
 | Remote OS cluster  | `make openshift-tests` with remote OpenShift context |
 | Docker on Mac      | `make minikube-test` on Mac with Docker              |
@@ -105,7 +105,7 @@ In order to run *all* possible code paths in Telepresence, you need to do the fo
 
 In practice running on remote OpenShift cluster usually doesn't happen.
 
-Travis on Mac cannot support Docker, which is why that needs to be done manually.
+CircleCI on Mac does not yet support Docker, which is why that needs to be done manually.
 
 #### Running individual tests
 


### PR DESCRIPTION
Stacked on top of #432 so review that first.

Removes the Travis configuration for running any of the test suite.  Also removes supporting build script code.  The release bits remain in the Travis configuration as CircleCI is not yet configured for that part.

Broken off of the #400 branch to try to make it a more manageable size.