### PR TITLE
Port test_loopback to test_endtoend

### DIFF
--- a/tests/probe_endtoend.py
+++ b/tests/probe_endtoend.py
@@ -35,8 +35,14 @@ def main():
 def probe_urls(urls):
     for url in urls:
         print("Retrieving {}".format(url))
-        result = urlopen(url, timeout=30).read().decode("utf-8")
-        print("Got result of length {} ".format(len(result)))
+        try:
+            response = urlopen(url, timeout=30).read()
+        except Exception as e:
+            print("Got error: {}".format(e))
+            result = (False, str(e))
+        else:
+            print("Got {} bytes".format(len(response)))
+            result = (True, response.decode("utf-8"))
         yield (url, result)
 
 

--- a/tests/probe_endtoend.py
+++ b/tests/probe_endtoend.py
@@ -14,16 +14,40 @@ from json import (
 from argparse import (
     ArgumentParser,
 )
+from urllib.request import (
+    urlopen
+)
 
 def main():
-    parser = ArgumentParser()
-    parser.parse_args()
+    parser = argument_parser()
+    args = parser.parse_args()
 
     result = dumps({
         "environ": dict(environ),
+        "probe-urls": list(probe_urls(args.probe_url)),
     })
+
 
     delimiter = "{probe delimiter}"
     print("{}{}{}".format(delimiter, result, delimiter))
+
+
+def probe_urls(urls):
+    for url in urls:
+        print("Retrieving {}".format(url))
+        result = urlopen(url, timeout=5).read().decode("utf-8")
+        print("Got result of length {} ".format(len(result)))
+        yield (url, result)
+
+
+def argument_parser():
+    parser = ArgumentParser()
+    parser.add_argument(
+        "--probe-url",
+        action="append",
+        help="A URL to retrieve.",
+    )
+    return parser
+
 
 main()

--- a/tests/probe_endtoend.py
+++ b/tests/probe_endtoend.py
@@ -35,7 +35,7 @@ def main():
 def probe_urls(urls):
     for url in urls:
         print("Retrieving {}".format(url))
-        result = urlopen(url, timeout=5).read().decode("utf-8")
+        result = urlopen(url, timeout=30).read().decode("utf-8")
         print("Got result of length {} ".format(len(result)))
         yield (url, result)
 

--- a/tests/test_endtoend.py
+++ b/tests/test_endtoend.py
@@ -136,7 +136,7 @@ def test_loopback_network_access(probe):
             result
             for url, result
             in probe_result.result["probe-urls"]
-            if url == probe.LOOPBACK_URL
+            if url == probe.loopback_url
         )
 
         # We're loading _this_ file via curl, so it should have the string

--- a/tests/test_endtoend.py
+++ b/tests/test_endtoend.py
@@ -132,9 +132,9 @@ def test_loopback_network_access(probe):
     """
     if probe.method.loopback_is_host():
         probe_result = probe.result()
-        response = next(
-            response
-            for url, response
+        (success, response) = next(
+            result
+            for url, result
             in probe_result.result["probe-urls"]
             if url == probe.LOOPBACK_URL
         )
@@ -142,4 +142,4 @@ def test_loopback_network_access(probe):
         # We're loading _this_ file via curl, so it should have the string
         # "cuttlefish" which is in this comment and unlikely to appear by
         # accident.
-        assert u"cuttlefish" in response
+        assert success and u"cuttlefish" in response

--- a/tests/test_endtoend.py
+++ b/tests/test_endtoend.py
@@ -122,3 +122,24 @@ def test_environment_for_services(probe):
         probe_environment[prefix] ==
         probe_environment[service_env + "_PORT"]
     )
+
+
+@with_probe
+def test_loopback_network_access(probe):
+    """
+    The Telepresence execution environment allows network access to the host
+    at the loopback address.
+    """
+    if probe.method.loopback_is_host():
+        probe_result = probe.result()
+        response = next(
+            response
+            for url, response
+            in probe_result.result["probe-urls"]
+            if url == probe.LOOPBACK_URL
+        )
+
+        # We're loading _this_ file via curl, so it should have the string
+        # "cuttlefish" which is in this comment and unlikely to appear by
+        # accident.
+        assert u"cuttlefish" in response

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -437,39 +437,6 @@ class NativeEndToEndTests(TestCase):
             79,
         )
 
-    def test_loopback(self):
-        """The shell run by telepresence can access localhost."""
-        p = Popen(["python3", "-m", "http.server", "12346"],
-                  cwd=str(DIRECTORY))
-
-        def cleanup():
-            p.terminate()
-            p.wait()
-
-        self.addCleanup(cleanup)
-
-        name = random_name()
-        p = Popen(
-            args=[
-                "telepresence",
-                "--method",
-                TELEPRESENCE_METHOD,
-                "--new-deployment",
-                name,
-                "--run-shell",
-            ],
-            stdin=PIPE,
-            stdout=PIPE,
-            cwd=str(DIRECTORY)
-        )
-        result, _ = p.communicate(
-            b"curl --silent http://localhost:12346/test_run.py\n"
-        )
-        # We're loading this file via curl, so it should have the string
-        # "cuttlefish" which is in this comment and unlikely to appear by
-        # accident.
-        assert b"cuttlefish" in result
-
     def test_disconnect(self):
         """Telepresence exits if the connection is lost."""
         exit_code = run_script_test(["--new-deployment", random_name()],


### PR DESCRIPTION
Step towards completing #400 

I haven't updated changelog.  Seems like it might not  be useful to do that for each individual test we port.  Probably worth a mention when everything has been ported, though?