### PR TITLE
Avoid tests during Linux env setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,7 +132,7 @@ jobs:
       - run:
           name: "setup Python environment"
           command: |
-            ./build --registry gcr.io/datawireio --manage-virtualenv
+            ./build --registry gcr.io/datawireio --manage-virtualenv --no-tests
 
       - run:
           name: "run tests"


### PR DESCRIPTION
The CircleCI configuration tells the Linux job  to run the test suite twice, accidentally.
