### PR TITLE
Port "tocluster" tests from test_run to test_endtoend

### DIFF
--- a/tests/parameterize_utils.py
+++ b/tests/parameterize_utils.py
@@ -389,7 +389,11 @@ def run_telepresence_probe(
         )
     else:
         writer = stdout.buffer
-        output = _read_tagged_output(telepresence, telepresence.stdout, writer)
+        output = _read_tagged_output(
+            telepresence,
+            telepresence.stdout,
+            writer,
+        ).decode("utf-8")
         try:
             probe_result = loads(output)
         except JSONDecodeError as e:

--- a/tests/parameterize_utils.py
+++ b/tests/parameterize_utils.py
@@ -395,7 +395,7 @@ def run_telepresence_probe(
             writer,
         ).decode("utf-8")
         try:
-            probe_result = loads(output)
+            initial_result = loads(output)
         except JSONDecodeError as e:
             assert False, "Could not decode JSON probe result from {}:\n{}".format(
                 ["telepresence"] + args, e.doc,
@@ -405,7 +405,7 @@ def run_telepresence_probe(
             telepresence,
             deployment_ident,
             webserver_name,
-            probe_result,
+            initial_result,
         )
 
 

--- a/tests/probe_endtoend.py
+++ b/tests/probe_endtoend.py
@@ -12,6 +12,9 @@ from sys import (
     stdin,
     stdout,
 )
+from struct import (
+    pack,
+)
 from os.path import (
     join,
 )
@@ -29,9 +32,34 @@ from subprocess import (
     check_output,
 )
 
+# The probe's output is mixed together with Telepresence output and maybe more
+# output from things like socat or torsocks.  This makes it difficult to
+# extract information from the probe via stdout.  Unfortunately, options apart
+# from stdout as a channel for communicating back to the test process are
+# limit.  Depending on the Telepresence method, it may not be easy for the
+# test process to reach the probe via normal networking means (we may not have
+# an address we can bind to that the host can reach; there may not be an
+# address on the host we can reach).  It's not possible to pass an
+# already-opened connection from the test process to the probe process because
+# it would need to pass through Telepresence and Telepresence doesn't support
+# this.  Even a UNIX socket on the host filesystem isn't necessarily reachable
+# from the probe process.
+#
+# So use the channel we have: stdout.  To deal with the fact that there is
+# other output on it, frame structured probe output with a magic prefix
+# followed by a length prefix followed by the content itself.  The test
+# process will have to filter through the noise to find the magic prefix and
+# then use the length prefix to know how much following data is relevant.
+#
+# The particular prefix chosen is not legal UTF-8.  Hopefully this minimizes
+# the chances that some legitimate output will accidentally duplicate it.
+MAGIC_PREFIX = b"\xc0\xc1\xfe\xff"
+
 def main():
     parser = argument_parser()
     args = parser.parse_args()
+
+    output = TaggedOutput(stdout.buffer)
 
     result = dumps({
         "environ": dict(environ),
@@ -40,19 +68,38 @@ def main():
         "probe-paths": list(probe_paths(args.probe_path)),
     })
 
-    delimiter = "{probe delimiter}"
-    print("{}{}{}".format(delimiter, result, delimiter), flush=True)
-
-    read_and_respond()
-
+    output.write(result)
+    read_and_respond(stdin.buffer, output)
+    print("Goodbye.")
 
 
-def read_and_respond():
-    for line in stdin:
-        command, argv = line.split()
+class TaggedOutput(object):
+    def __init__(self, stdout):
+        self.stdout = stdout
+
+
+    def write(self, text):
+        data = text.encode("utf-8")
+        self.stdout.write(MAGIC_PREFIX + pack(">I", len(data)) + data)
+        self.stdout.flush()
+
+
+
+def read_and_respond(commands, output):
+    while True:
+        line = commands.readline().decode("utf-8")
+        print("Read line: {!r}".format(line), flush=True)
+        if not line:
+            print("Closed? {}".format(commands.closed), flush=True)
+            from time import sleep
+            sleep(1)
+            continue
+        argv = line.split()
+        command = argv.pop(0)
+        print("Read command: {}".format(command), flush=True)
         response = COMMANDS[command](*argv)
-        stdout.write(dumps(response) + "\n")
-        stdout.flush()
+        output.write(dumps(response))
+        print("Dumped response.", flush=True)
 
 
 

--- a/tests/probe_endtoend.py
+++ b/tests/probe_endtoend.py
@@ -8,6 +8,10 @@ created the execution context correctly.
 from os import (
     environ,
 )
+from sys import (
+    stdin,
+    stdout,
+)
 from os.path import (
     join,
 )
@@ -37,7 +41,25 @@ def main():
     })
 
     delimiter = "{probe delimiter}"
-    print("{}{}{}".format(delimiter, result, delimiter))
+    print("{}{}{}".format(delimiter, result, delimiter), flush=True)
+
+    read_and_respond()
+
+
+
+def read_and_respond():
+    for line in stdin:
+        command, argv = line.split()
+        response = COMMANDS[command](*argv)
+        stdout.write(dumps(response) + "\n")
+        stdout.flush()
+
+
+
+COMMANDS = {
+    "probe-url": lambda *urls: list(probe_urls(urls)),
+}
+
 
 
 def probe_urls(urls):


### PR DESCRIPTION
Another step towards #400 

Apart from porting some tests that exercise network traffic from Telepresence execution context to the Kubernetes cluster, this also introduces a long-running probe process.  The probe process now keeps running from before the first test that needs its particular config until after the last test is done.  This allows the tests to interact with the process which facilitates some of the tests ported here (for example, retrieving the environment from the probe and using it to construct a url to ask the probe to retrieve, then checking the result of that operation).