### PR TITLE
Port some argument parsing tests

### DIFF
--- a/telepresence/cli.py
+++ b/telepresence/cli.py
@@ -120,7 +120,7 @@ class handle_unexpected_errors(object):
 
 
 @handle_unexpected_errors("-")
-def parse_args() -> argparse.Namespace:
+def parse_args(args=None) -> argparse.Namespace:
     """Create a new ArgumentParser and parse sys.argv."""
     parser = argparse.ArgumentParser(
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -274,7 +274,7 @@ def parse_args() -> argparse.Namespace:
             "Requires --method container."
         )
     )
-    args = parser.parse_args()
+    args = parser.parse_args(args)
 
     # Fill in defaults:
     if args.method is None:

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -153,49 +153,6 @@ class NativeEndToEndTests(TestCase):
     End-to-end tests on the native machine.
     """
 
-    @skipIf(TELEPRESENCE_METHOD != "vpn-tcp", "this uses vpn-tcp.")
-    def test_run_directly_implicit_method(self):
-        """--method is optional."""
-        webserver_name = run_webserver()
-        p = Popen(
-            args=[
-                "telepresence",
-                "--new-deployment",
-                random_name(),
-                "--logfile",
-                "-",
-                "--run",
-                "python3",
-                "tocluster.py",
-                webserver_name,
-                current_namespace(),
-            ],
-            cwd=str(DIRECTORY),
-        )
-        exit_code = p.wait()
-        assert exit_code == 113
-
-    def test_run_directly_implicit_deployment(self):
-        """--*deployment is optional."""
-        webserver_name = run_webserver()
-        p = Popen(
-            args=[
-                "telepresence",
-                "--method",
-                TELEPRESENCE_METHOD,
-                "--logfile",
-                "-",
-                "--run",
-                "python3",
-                "tocluster.py",
-                webserver_name,
-                current_namespace(),
-            ],
-            cwd=str(DIRECTORY),
-        )
-        exit_code = p.wait()
-        assert exit_code == 113
-
     @skipIf(OPENSHIFT, "OpenShift Online doesn't do namespaces")
     def create_namespace(self):
         """Create a new namespace, return its name."""

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -256,3 +256,30 @@ def test_docker_publish_args():
     for variant in publish_variants:
         assert parse_docker_args(variant.split()) == \
                (expected_docker, expected_publish)
+
+
+def test_default_method():
+    """
+    The ``--method`` argument is optional and defaults to *vpn-tcp*.
+    """
+    args = telepresence.cli.parse_args([])
+    assert args.method == "vpn-tcp"
+
+
+def test_docker_run_implies_container_method():
+    """
+    If a value is given for the ``--docker-run`` argument then the method is
+    *container*.
+    """
+    args = telepresence.cli.parse_args(["--docker-run", "foo:latest", "/bin/bash"])
+    assert args.method == "container"
+
+
+def test_default_operation():
+    """
+    The default operation is ``--new-deployment``.
+    """
+    args = telepresence.cli.parse_args([])
+    assert args.new_deployment is not None
+    assert args.deployment is None
+    assert args.swap_deployment is None


### PR DESCRIPTION
Another step towards #400.

These tests don't need to be end-to-end.  They're just argparser unit tests.
