### PR TITLE
Fixing Ubuntu install instructions

### DIFF
--- a/docs/macros.html
+++ b/docs/macros.html
@@ -32,7 +32,7 @@ brew install socat datawire/blackbird/telepresence
 
 <h4>Ubuntu 16.04 or later</h4>
 <p>Run the following to install Telepresence:</p>
-<button data-system="ubuntu" data-location="{{ location }}" class="button fa-pull-right copy-to-clipboard" data-clipboard-text="curl -s https://packagecloud.io/install/repositories/datawireio/telepresence/script.deb.sh | sudo bash&#xa;sudo apt install --no-install-recommends telepresence">Copy to clipboard</button>
+<button data-system="ubuntu" data-location="{{ location }}" class="button fa-pull-right copy-to-clipboard" data-clipboard-text="curl -s https://packagecloud.io/install/repositories/datawireio/telepresence/script.deb.sh | sudo bash&#xa;sudo apt update&#xa;sudo apt install --no-install-recommends telepresence">Copy to clipboard</button>
 
 <pre class="install-instructions" data-system="ubuntu" data-location="{{ location }}"><code>curl -s https://packagecloud.io/install/repositories/datawireio/telepresence/script.deb.sh | sudo bash
 sudo apt install --no-install-recommends telepresence


### PR DESCRIPTION
Adding `sudo apt update` otherwise you get `E: Unable to locate package telepresence`

(Assuming small doc fixes are not added to changelog. Let me know if they are.)
