### PR TITLE
Randomize the hostPorts used by the end-to-end test suite

### DIFF
--- a/telepresence/deployment.py
+++ b/telepresence/deployment.py
@@ -41,7 +41,10 @@ def create_new_deployment(runner: Runner,
         "--image=" + TELEPRESENCE_REMOTE_IMAGE,
         "--labels=telepresence=" + run_id,
     ]
-    for port in args.expose.remote():
+    # Provide a stable argument ordering.  Reverse it because that happens to
+    # make some current tests happy but in the long run that's totally
+    # arbitrary and doesn't need to be maintained.  See issue 494.
+    for port in sorted(args.expose.remote(), reverse=True):
         command.append("--port={}".format(port))
     if args.expose.remote():
         command.append("--expose")

--- a/tests/parameterize_utils.py
+++ b/tests/parameterize_utils.py
@@ -187,13 +187,14 @@ class _ExistingDeploymentOperation(object):
             # command is restored after Telepresence swaps the original deployment
             # back in.
             self.container_args = ["/hello-openshift"]
-            same_port = random_port()
             self.http_server_auto_expose_same = HTTPServer(
-                same_port,
-                same_port,
+                random_port(),
+                None,
                 random_name("auto-same"),
             )
-            print("HTTP Server auto-expose same-port: {}".format(same_port))
+            print("HTTP Server auto-expose same-port: {}".format(
+                self.http_server_auto_expose_same.remote_port,
+            ))
             self.http_server_auto_expose_diff = HTTPServer(
                 12330,
                 random_port(),

--- a/tests/parameterize_utils.py
+++ b/tests/parameterize_utils.py
@@ -68,7 +68,9 @@ class _RandomPortAssigner(object):
         self.high = high
 
     def __iter__(self):
-        return iter(shuffle(randrange(self.low, self.high)))
+        ports = list(range(self.low, self.high))
+        shuffle(ports)
+        return iter(ports)
 
 
 _random_ports = iter(_RandomPortAssigner(20000, 40000))

--- a/tests/parameterize_utils.py
+++ b/tests/parameterize_utils.py
@@ -177,11 +177,15 @@ class _ExistingDeploymentOperation(object):
                 same_port,
                 random_name("auto-same"),
             )
+            print("HTTP Server auto-expose same-port: {}".format(same_port))
             self.http_server_auto_expose_diff = HTTPServer(
                 12330,
                 randrange(20000, 40000),
                 random_name("auto-diff"),
             )
+            print("HTTP Server auto-expose diff-port: {}".format(
+                self.http_server_auto_exposxe_diff.remote_port,
+            ))
         else:
             self.name = "existing"
             self.image = "{}/telepresence-k8s:{}".format(

--- a/tests/parameterize_utils.py
+++ b/tests/parameterize_utils.py
@@ -601,6 +601,7 @@ def run_telepresence_probe(
     ])
 
     # Tell the operation to prepare a service exposing those ports.
+    print("Creating service with ports {}".format(service_ports))
     operation.prepare_service(deployment_ident, service_ports)
 
     probe_args = []

--- a/tests/parameterize_utils.py
+++ b/tests/parameterize_utils.py
@@ -1,4 +1,7 @@
 import os
+from random import (
+    randrange,
+)
 from time import (
     sleep,
 )
@@ -168,14 +171,15 @@ class _ExistingDeploymentOperation(object):
             # command is restored after Telepresence swaps the original deployment
             # back in.
             self.container_args = ["/hello-openshift"]
+            same_port = randrange(20000, 40000)
             self.http_server_auto_expose_same = HTTPServer(
-                12340,
-                12340,
+                same_port,
+                same_port,
                 random_name("auto-same"),
             )
             self.http_server_auto_expose_diff = HTTPServer(
                 12330,
-                12331,
+                randrange(20000, 40000),
                 random_name("auto-diff"),
             )
         else:

--- a/tests/parameterize_utils.py
+++ b/tests/parameterize_utils.py
@@ -1,5 +1,6 @@
 import os
 from random import (
+    shuffle,
     randrange,
 )
 from functools import (
@@ -56,8 +57,27 @@ def retry(condition, function):
             return result
 
 
+class _RandomPortAssigner(object):
+    """
+    Provide ports in the requested range in an unstable order and
+    without replacement.  This reduces the chances that concurrent runs
+    of the test suite will try to use the same port number.
+    """
+    def __init__(self, low, high):
+        self.low = low
+        self.high = high
+
+    def __iter__(self):
+        return iter(shuffle(randrange(self.low, self.high)))
+
+
+_random_ports = iter(_RandomPortAssigner(20000, 40000))
 def random_port():
-    return randrange(20000, 40000)
+    """
+    :return int: A port number which is unique within the scope of this
+        process.
+    """
+    return next(_random_ports)
 
 
 class HTTPServer(object):

--- a/tests/parameterize_utils.py
+++ b/tests/parameterize_utils.py
@@ -881,7 +881,9 @@ class Probe(object):
     HTTP_SERVER_LOW_PORT = HTTPServer(
         12350,
         # This needs to be allocated from the privileged range.  Try to avoid
-        # values that are obviously going to fail.
+        # values that are obviously going to fail.  We only allocate one
+        # low-value port number so we don't need special steps to avoid
+        # reusing one.
         retry({22, 80, 111, 443}.__contains__, partial(randrange, 1, 1024)),
         random_name("low"),
     )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -102,7 +102,7 @@ def random_name(suffix=""):
         suffix = "-" + suffix
     hostname = socket.gethostname()
     return "testing-{}-{}-{}-{}{}".format(
-        REVISION, hostname, os.getpid(), int(time.time() - START_TIME), suffix
+        REVISION, hostname[:16], os.getpid(), int(time.time() - START_TIME), suffix
     ).replace(".", "-")
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,6 +2,7 @@
 
 import atexit
 from pathlib import Path
+import socket
 import time
 import os
 from json import dumps
@@ -99,8 +100,9 @@ def random_name(suffix=""):
     """Return a new name each time."""
     if suffix and not suffix.startswith("-"):
         suffix = "-" + suffix
-    return "testing-{}-{}-{}{}".format(
-        REVISION, os.getpid(), time.time() - START_TIME, suffix
+    hostname = socket.gethostname()
+    return "testing-{}-{}-{}-{}{}".format(
+        REVISION, hostname, os.getpid(), time.time() - START_TIME, suffix
     ).replace(".", "-")
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -102,7 +102,7 @@ def random_name(suffix=""):
         suffix = "-" + suffix
     hostname = socket.gethostname()
     return "testing-{}-{}-{}-{}{}".format(
-        REVISION, hostname, os.getpid(), time.time() - START_TIME, suffix
+        REVISION, hostname, os.getpid(), int(time.time() - START_TIME), suffix
     ).replace(".", "-")
 
 


### PR DESCRIPTION
Fixes #511 

Each run of `test_endtoend.py` will now select different "remote" ports (ie `hostPort`\ s).  This will prevent concurrent test runs from wanting to have a Kubernetes node bind the same port number.  Since there are only a handful of Kubernetes nodes and each can only bind any given port number once, this will avoid the unnecessarily tight bottleneck of only being able to have a handful of concurrent test runs.  It also makes the Kubernetes pod scheduler's job a little easier which I guess is a good thing.

This also includes a change to include the hostname where the test suite is running in the randomly generated names.  I found this helpful for filtering out Kubernetes resources that belonged to _my_ test runs when inspecting the cluster.

This also includes a change to make the order of `--port` arguments Telepresence passes to `kubectl run` deterministic so that the resulting behavior with respect to #494 is deterministic.