### PR TITLE
Increase container networking timeout (fixes #340 and #539)

### DIFF
--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -1,5 +1,14 @@
 # Changelog
 
+#### 0.78 (Unreleased)
+
+Bug fixes:
+
+* When using the container method, Telepresence waits longer for networking to start before giving up.
+  This may help users who sometimes experience higher latency between their local network and their Kubernetes cluster.
+  ([#340](https://github.com/datawire/telepresence/issues/340))
+  ([#539](https://github.com/datawire/telepresence/issues/539))
+
 #### 0.77 (March 26, 2018)
 
 Misc:

--- a/local-docker/entrypoint.py
+++ b/local-docker/entrypoint.py
@@ -96,14 +96,12 @@ def proxy(config: dict):
 def wait():
     """Wait for proxying to be live."""
     start = time()
-    while time() - start < 10:
+    while time() - start < 30:
         try:
             gethostbyname("hellotelepresence")
             sleep(1)  # just in case there's more to startup
             sys.exit(100)
         except gaierror:
-            sleep(0.1)
-        else:
             sleep(0.1)
     sys.exit("Failed to connect to proxy in remote cluster.")
 


### PR DESCRIPTION

---
Before landing
- Update `docs/reference/changelog.md`
- Link to applicable GH issues in the changelog
