### PR TITLE
Populate CalledProcessError with command output

### DIFF
--- a/telepresence/remote.py
+++ b/telepresence/remote.py
@@ -99,8 +99,8 @@ def get_deployment_json(
             )["items"][0]
     except CalledProcessError as e:
         raise SystemExit(
-            "Failed to find Deployment '{}': {}".format(
-                deployment_name, str(e.stdout, "utf-8")
+            "Failed to find Deployment '{}':\n{}".format(
+                deployment_name, e.stdout
             )
         )
     finally:

--- a/telepresence/runner.py
+++ b/telepresence/runner.py
@@ -245,14 +245,21 @@ class Runner(object):
         else:
             out_cb = capture.append
         err_cb = self.make_logger(track)
-        self.run_command(
-            track, "Capturing", "captured", out_cb, err_cb, args, **kwargs
-        )
+        cpe_exc = None
+        try:
+            self.run_command(
+                track, "Capturing", "captured", out_cb, err_cb, args, **kwargs
+            )
+        except CalledProcessError as exc:
+            cpe_exc = exc
         # Wait for end of stream to be recorded
         while not capture or capture[-1] is not None:
             sleep(0.1)
         del capture[-1]
-        return "".join(capture).strip()
+        output = "".join(capture).strip()
+        if cpe_exc:
+            raise CalledProcessError(cpe_exc.returncode, cpe_exc.cmd, output)
+        return output
 
     def popen(self, args, **kwargs) -> Popen:
         """Return Popen object."""


### PR DESCRIPTION
... so that the output can be used in error messages if a command fails.


---
Before landing, add a changelog entry as a file `newsfragments/issue_number.type`, where `type` is one of `incompat`, `feature`, `bugfix`, or `misc`. Preview the changelog with `virtualenv/bin/towncrier --draft`. 

E.g., `532.bugfix` would contain the text "Telepresence should no longer get confused looking for the route to the host when using the container method."
