### PR TITLE
add Ironclad post to community page

### DIFF
--- a/docs/reference/community.md
+++ b/docs/reference/community.md
@@ -33,4 +33,7 @@ The team at [vizual.ai](https://www.vizual.ai) uses Spark for analyzing and mode
 ##### [Writing golang applications designed to run in Kubernetes](https://github.com/number101010/go-kubernetes-vscode-dev) - number101010
 This repo is a template to get started writing golang applications designed to run in Kubernetes and uses Telepresence to mimic the in-cluster environment.
 
+##### [Towards a better service development story](https://blog.ironcladapp.com/towards-a-better-service-development-story-bae19a9b3c5a) - Dylan Scott
+The team at Ironclad is using Telepresnece to develop individual Kubernetes services and improve their development workflow on Kubernetes. 
+
 ###### If you're interested in sharing your use case for Telepresence, we'd love to hear it! You can reach out to us in the [Gitter chatroom](https://gitter.im/datawire/telepresence) or [submit a pull request](https://github.com/datawire/telepresence/pulls).


### PR DESCRIPTION

---
Before landing, add a changelog entry as a file `newsfragments/issue_number.type`, where `type` is one of `incompat`, `feature`, `bugfix`, or `misc`. Preview the changelog with `virtualenv/bin/towncrier --draft`. 

E.g., `532.bugfix` would contain the text "Telepresence should no longer get confused looking for the route to the host when using the container method."
