### PR TITLE
Remove kubecon banner

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -36,20 +36,6 @@
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KMVFH7G"
                   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-
-<aside id="announcement-widget" class="alert alert-dismissable alert-primary">
-    <button class="close" data-dismiss="alert">&times;</button>
-    <div class="container">
-        <div class="announcement-widget__content">
-            <p>
-                At KubeCon EU? Stop by the Datawire Booth SU-C10 to see a demo of Telepresence as well as our
-                other open source tools <a target="_blank" href="https://www.forge.sh">Forge</a> and
-                <a target="_blank" href="https://www.getambassador.io">Ambassador</a>
-            </p>
-        </div>
-    </div>
-</aside>
-
 <header class="white-bg">
     <a class="datawire-link" target="_blank" href="https://www.datawire.io">
         <img alt="Datawire" src="/images/datawire-logo.svg">


### PR DESCRIPTION

---
Make sure every source file you touch has the standard license header.

Before landing, add a changelog entry as a file `newsfragments/issue_number.type`, where `type` is one of `incompat`, `feature`, `bugfix`, or `misc`. Preview the changelog with `virtualenv/bin/towncrier --draft`. 

E.g., `532.bugfix` would contain the text "Telepresence should no longer get confused looking for the route to the host when using the container method."
