### PR TITLE
Add iris tv case study

### DIFF
--- a/docs/case-studies/iris-tv.html
+++ b/docs/case-studies/iris-tv.html
@@ -6,7 +6,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <title>Case Studies - Telepresence</title>
+    <title>IRIS.TV Case Study - Telepresence</title>
     <meta name="description" content="Telepresence: a local development environment for a remote Kubernetes cluster">
     <meta name="keywords" content="Telepresence, Kubernetes, microservices">
     <meta name="author" content="Datawire.io">
@@ -61,41 +61,43 @@
         </li>
     </ul>
 </header>
-<div class="bg-white page-title">
+<section id="case-study" class="bg-white">
+
     <div class="container">
-        <h1>Telepresence Case Studies</h1>
-    </div>
-</div>
-<div class="case-studies-bg bg-gray padding-bottom-75">
-    <div class="container">
-        <div class="case-studies">
-            <a class="case-study" href="/case-studies/verloop">
-                <div>
-                    <img src="https://www.datawire.io/wp-content/uploads/2018/03/verloop-logo.png">
-                </div>
-                <span class="case-study-btn">View Case Study</span>
-            </a>
-            <a class="case-study" href="/case-studies/sight-machine">
-                <div>
-                    <img src="https://www.datawire.io/wp-content/uploads/2018/03/logo_sight_machine-300x206.png">
-                </div>
-                <span class="case-study-btn">View Case Study</span>
-            </a>
-            <a class="case-study" href="/case-studies/iris-tv">
-                <div>
-                    <img src="https://www.datawire.io/wp-content/uploads/2018/03/iris_tv_logo.png">
-                </div>
-                <span class="case-study-btn">View Case Study</span>
-            </a>
-            <a class="case-study" href="https://datawire.com/contact">
-                <div>
-                    <p>Have a Telepresence story to share?</p>
-                </div>
-                <span class="case-study-btn">Contact Us</span>
-            </a>
+        <h1 class="title">IRIS.TV</h1>
+
+        <h2>Can you tell us about yourself and what your company does?</h2>
+        <p>
+            I’m Blake Miller, Platform Architect at IRIS.TV. IRIS.TV is a video personalization and programming platform.
+            Media customers use IRIS.TV to increase their video views and audience engagement, among other things.
+            The IRIS.TV platform consists of about 30 services, written in a wide variety of programming languages
+            including Ruby, Python, JavaScript, Clojure, R, and Go. In addition, there are a wide variety of stateful
+            services including Redis, Kafka, MongoDB, Cassandra, and MySQL.
+        </p>
+        <h2>Why did you choose Datawire’s Telepresence and Forge?</h2>
+        <p>
+            We’re working to improve productivity, accuracy, and autonomy, which is especially important as we begin
+            adding remote engineers. We wanted to reduce the cognitive burden of each engineer maintaining a
+            development environment, so our engineers can focus as much as possible on the specific challenges and
+            opportunities of our business. We are also evolving our production infrastructure towards microservices in
+            Kubernetes and need an efficient and complete development setup in that context. When I heard the approach
+            that these tools take, I was immediately excited to try it. The alternative is quite cumbersome.
+        </p>
+        <h2>Do you have any advice for people looking to adopt Datawire?</h2>
+        <p>
+            Best practices around development workflow definitely take time to get right, they need to fit your
+            organization, and they warrant a lot of consideration since they impact everything you do. There is no
+            "one size fits all" approach. This is an ongoing process, it's important to continue examining (ideally,
+            measuring) the way your team works, reflecting on it, and refining it. Testing your workflow with a small
+            set of users, and incrementally rolling it out is a good strategy. Also, talk with the Datawire team on
+            their Gitter chat, they can provide good advice and perspective.
+        </p>
+        <div class="text-center">
+            <a href="/#get-started" class="btn btn-black">Get Started</a>
         </div>
     </div>
-</div>
+
+</section>
 <footer class="white-bg">
     <ul class="main-navigation flex-center">
         <li>

--- a/docs/styles/home.css
+++ b/docs/styles/home.css
@@ -698,6 +698,8 @@ footer {
     box-shadow: 0 5px 6px 0 rgba(0,0,0,0.15);
     padding: 50px 20px;
     border: 1px solid #eee;
+    min-width: 310px;
+    max-width: 310px;
 }
 .case-study:hover {
     text-decoration: none;


### PR DESCRIPTION

---
Make sure every source file you touch has the standard license header.

Before landing, add a changelog entry as a file `newsfragments/issue_number.type`, where `type` is one of `incompat`, `feature`, `bugfix`, or `misc`. Preview the changelog with `virtualenv/bin/towncrier --draft`. 

E.g., `532.bugfix` would contain the text "Telepresence should no longer get confused looking for the route to the host when using the container method."
