### PR TITLE
Environment fixes and env file generation

### DIFF
--- a/newsfragments/301.bugfix
+++ b/newsfragments/301.bugfix
@@ -1,0 +1,1 @@
+The container method now supports multi-line environment variable values.

--- a/newsfragments/597.bugfix
+++ b/newsfragments/597.bugfix
@@ -1,0 +1,1 @@
+Telepresence can now transfer complex environment variable values without truncating or mangling them.

--- a/newsfragments/608.feature
+++ b/newsfragments/608.feature
@@ -1,0 +1,3 @@
+Telepresence can optionally emit the remote environment as a JSON blob or as a `.env`-format file.
+Use the `--env-json` or `--env-file` options respectively to specify the desired filenames.
+See https://docs.docker.com/compose/env-file/ for information about the limitations of the Docker Compose-style `.env` file format.

--- a/telepresence/cli.py
+++ b/telepresence/cli.py
@@ -302,6 +302,25 @@ def parse_args(args=None) -> argparse.Namespace:
         )
     )
 
+    parser.add_argument(
+        "--env-json",
+        metavar="FILENAME",
+        default=None,
+        help="Also emit the remote environment to a file as a JSON blob."
+    )
+
+    parser.add_argument(
+        "--env-file",
+        metavar="FILENAME",
+        default=None,
+        help=(
+            "Also emit the remote environment to an env file in Docker "
+            "Compose format. "
+            "See https://docs.docker.com/compose/env-file/ for more "
+            "information on the limitations of this format."
+        )
+    )
+
     group = parser.add_mutually_exclusive_group()
     group.add_argument(
         "--run-shell",

--- a/telepresence/container.py
+++ b/telepresence/container.py
@@ -126,12 +126,6 @@ def run_docker_command(
         ), make_docker_kill(runner, name)
     )
 
-    # Write out env file:
-    with NamedTemporaryFile("w", delete=False) as envfile:
-        for key, value in remote_env.items():
-            envfile.write("{}={}\n".format(key, value))
-    atexit.register(os.remove, envfile.name)
-
     # Wait for sshuttle to be running:
     while True:
         try:
@@ -162,10 +156,17 @@ def run_docker_command(
     docker_command = docker_runify([
         "--name=" + container_name,
         "--network=container:" + name,
-        "--env-file=" + envfile.name,
     ])
+
+    # Prepare container environment
+    for key in remote_env:
+        docker_command.append("-e={}".format(key))
+    docker_env = os.environ.copy()
+    docker_env.update(remote_env)
+
     if mount_dir:
         docker_command.append("--volume={}:{}".format(mount_dir, mount_dir))
+
     # Don't add --init if the user is doing something with it
     init_args = [
         arg for arg in docker_args
@@ -178,7 +179,8 @@ def run_docker_command(
         docker_command += ["--init"]
     docker_command += docker_args
     span.end()
-    p = Popen(docker_command)
+
+    p = Popen(docker_command, env=docker_env)
 
     def terminate_if_alive():
         runner.write("Shutting down containers...\n")

--- a/telepresence/container.py
+++ b/telepresence/container.py
@@ -22,7 +22,6 @@ from typing import List, Callable, Dict, Tuple, Optional
 
 import os
 import os.path
-from tempfile import NamedTemporaryFile
 
 from telepresence import TELEPRESENCE_LOCAL_IMAGE
 from telepresence.cleanup import Subprocesses

--- a/telepresence/container.py
+++ b/telepresence/container.py
@@ -90,8 +90,6 @@ def run_docker_command(
         mounted.
     """
     # Update environment:
-    if mount_dir:
-        remote_env["TELEPRESENCE_ROOT"] = mount_dir
     remote_env["TELEPRESENCE_METHOD"] = "container"  # mostly just for tests :(
 
     # Extract --publish flags and add them to the sshuttle container, which is

--- a/telepresence/local.py
+++ b/telepresence/local.py
@@ -151,9 +151,6 @@ def run_local_command(
     unsupported_tools_path = get_unsupported_tools(args.method != "inject-tcp")
     env["PATH"] = unsupported_tools_path + ":" + env["PATH"]
 
-    if mount_dir:
-        env["TELEPRESENCE_ROOT"] = mount_dir
-
     # Make sure we use "bash", no "/bin/bash", so we get the copied version on
     # OS X:
     if args.run is None:

--- a/telepresence/main.py
+++ b/telepresence/main.py
@@ -84,6 +84,7 @@ def main(session):
         # Used by mount_remote
         session.ssh = ssh
         session.remote_info = remote_info
+        session.env = env
 
         # Handle filesystem stuff (pod name, ssh object)
         mount_dir = mount_remote(session)

--- a/telepresence/main.py
+++ b/telepresence/main.py
@@ -28,7 +28,7 @@ from telepresence.local import run_local_command
 from telepresence.output import Output
 from telepresence.proxy import start_proxy, connect
 from telepresence.mount import mount_remote
-from telepresence.remote_env import get_remote_env
+from telepresence.remote_env import get_remote_env, write_env_files
 from telepresence.startup import analyze_args
 from telepresence.usage_tracking import call_scout
 
@@ -88,6 +88,9 @@ def main(session):
 
         # Handle filesystem stuff (pod name, ssh object)
         mount_dir = mount_remote(session)
+
+        # Maybe write environment files
+        write_env_files(session)
 
         # Set up outbound networking (pod name, ssh object)
         # Launch user command with the correct environment (...)

--- a/telepresence/mount.py
+++ b/telepresence/mount.py
@@ -117,6 +117,7 @@ def mount_remote(session):
             args.method == "container",  # allow all users
             mount_dir,
         )
+        session.env["TELEPRESENCE_ROOT"] = mount_dir
         atexit.register(mount_cleanup)
     else:
         mount_dir = None

--- a/tests/parameterize_utils.py
+++ b/tests/parameterize_utils.py
@@ -779,6 +779,14 @@ class AlsoProxy(object):
         self.host = host
 
 
+_json_blob = """{
+    "a": "b",
+    "c": "d",
+    "really long key": "really long value",
+    "multiline key": "-----BEGIN PGP PUBLIC KEY BLOCK-----\nmQENBFrVHZEBCACuD163edXBofnt8qNyluDufnIp0PucPZmK0lUuaJT/xi5RRki+\ntakVww0LGwPn6mcTI2Tgb2cEIvwk7yyXC5yPOPdWchUCxhfeadIgytDPOm3g51zG\nh/Ob1VH067nZlL1qJ7We4ZP0NGpT+MSVDYwGFROMoliRLe5bqz3SZgCI+GgXiHDU\nNbvkxAHE6Z5ZxkzAjBnJDmOf9kdnIHZvuBAVylHUorjTLN2jxJOQYFx7nqwbaOsA\n6i/5W4/CYm2NwPb09I4H2Hi8qQQ1PN5WV+Ky3PngE6yZTMRk34b1aV5VLJPf3yoi\nfqaqjX9xIetMvg6DZP0FiPqC66DESaEz1rv5ABEBAAG0EHRlc3RAZXhhbXBsZS5j\nb22JARwEEAECAAYFAlrVHZEACgkQ1A1oULTM9GYCigf9EWVBQwsG6LxmjhZ5bFyx\n8WT3H86tUhMgvmPGZEV/jl7VUG69DcGb2mhevN8F3mM/V+6njREwCmF9qKbY5HJj\npgG46Rsm6UrbZVH23CRnHFsQ7M0inyZ1CrhCyMETZYHpKOs7lIdAHH1q9F8fTIW6\n9KTnSe0LQpiV5tNxg2EJzCNYpvyvTOA0mGbi+XbjQJDGKr1xqfMYBr79Os9N/dGe\ncWrpBoHLAzB07ZC5CxdXo7Z21i+cTlTM/2c4tE9dLth3Yzzw9fqXyRqlrG1K8Bmz\n8LKhIHctewW9a6M7JTp48p7fRZiCir7N9Zj0hq6zry8+FHnkZIvFNOHFcbUrfS2Y\n2g==\n=rNSt\n-----END PGP PUBLIC KEY BLOCK-----",
+    "one last key": "this last value"
+}"""
+
 
 class Probe(object):
     CLIENT_ENV_VAR = "SHOULD_NOT_BE_SET"
@@ -786,16 +794,11 @@ class Probe(object):
     DESIRED_ENVIRONMENT = {
         "MYENV": "hello",
         "EXAMPLE_ENVFROM": "foobar",
-
-        # XXXX
-        # Container method doesn't support multi-line environment variables.
-        # Therefore disable this for all methods or the container tests all
-        # fail...
-        # XXXX
-        # "EX_MULTI_LINE": (
-        #     "first line (no newline before, newline after)\n"
-        #     "second line (newline before and after)\n"
-        # ),
+        "EX_MULTI_LINE": (
+            "first line = (no newline before, newline after)\n"
+            "second line = (newline before and after)\n"
+        ),
+        "EX_JSON_BLOB_FROM_597": _json_blob,
     }
 
     # A resource available from a server running on the Telepresence host


### PR DESCRIPTION

---
Make sure every source file you touch has the standard license header.

Before landing, add a changelog entry as a file `newsfragments/issue_number.type`, where `type` is one of `incompat`, `feature`, `bugfix`, or `misc`. Preview the changelog with `virtualenv/bin/towncrier --draft`. 

E.g., `532.bugfix` would contain the text "Telepresence should no longer get confused looking for the route to the host when using the container method."
