### PR TITLE
Strip out pod lifecycle hooks in swap-deployment. Fixes #587

### DIFF
--- a/newsfragments/587.bugfix
+++ b/newsfragments/587.bugfix
@@ -1,0 +1,1 @@
+Telepresence avoids running afoul of lifecycle hooks when swapping a deployment.

--- a/telepresence/deployment.py
+++ b/telepresence/deployment.py
@@ -215,7 +215,7 @@ def new_swapped_deployment(
             # Drop unneeded fields:
             for unneeded in [
                 "command", "args", "livenessProbe", "readinessProbe",
-                "workingDir"
+                "workingDir", "lifecycle"
             ]:
                 try:
                     container.pop(unneeded)

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -104,6 +104,13 @@ spec:
           name: secret-volume
         - mountPath: /etc/nginx/conf.d
           name: configmap-volume
+        lifecycle:
+          postStart:
+            exec:
+              command: ["/bin/sh", "-c", "echo postStart handler"]
+          preStop:
+            exec:
+              command: ["/usr/sbin/nginx","-s","quit"]
 """
 
 SWAPPED_DEPLOYMENT = """\


### PR DESCRIPTION

---
Make sure every source file you touch has the standard license header.

Before landing, add a changelog entry as a file `newsfragments/issue_number.type`, where `type` is one of `incompat`, `feature`, `bugfix`, or `misc`. Preview the changelog with `virtualenv/bin/towncrier --draft`. 

E.g., `532.bugfix` would contain the text "Telepresence should no longer get confused looking for the route to the host when using the container method."
